### PR TITLE
🔧 Update File Centric Mapping to Include `metrics` Object

### DIFF
--- a/mappings/platform_file_centric.json
+++ b/mappings/platform_file_centric.json
@@ -666,18 +666,18 @@
           "total_reads": {
             "type": "long"
           }
-        },
-        "meta": {
-          "properties": {
-            "study_id": {
-              "type": "keyword"
-            },
-            "release_state": {
-              "type": "keyword"
-            },
-            "embargo_stage": {
-              "type": "keyword"
-            }
+        }
+      },
+      "meta": {
+        "properties": {
+          "study_id": {
+            "type": "keyword"
+          },
+          "release_state": {
+            "type": "keyword"
+          },
+          "embargo_stage": {
+            "type": "keyword"
           }
         }
       }

--- a/mappings/platform_file_centric.json
+++ b/mappings/platform_file_centric.json
@@ -666,6 +666,19 @@
           "total_reads": {
             "type": "long"
           }
+        },
+        "meta": {
+          "properties": {
+            "study_id": {
+              "type": "keyword"
+            },
+            "release_state": {
+              "type": "keyword"
+            },
+            "embargo_stage": {
+              "type": "keyword"
+            }
+          }
         }
       }
     }

--- a/mappings/platform_file_centric.json
+++ b/mappings/platform_file_centric.json
@@ -626,6 +626,47 @@
         "copy_to": [
           "file_autocomplete"
         ]
+      },
+      "metrics": {
+        "type": "nested",
+        "properties": {
+          "average_insert_size": {
+            "type": "float"
+          },
+          "average_length": {
+            "type": "integer"
+          },
+          "duplicated_bases": {
+            "type": "long"
+          },
+          "error_rate": {
+            "type": "float"
+          },
+          "mapped_bases_cigar": {
+            "type": "long"
+          },
+          "mapped_reads": {
+            "type": "long"
+          },
+          "mismatch_bases": {
+            "type": "long"
+          },
+          "paired_reads": {
+            "type": "long"
+          },
+          "pairs_on_different_chromosomes": {
+            "type": "long"
+          },
+          "properly_paired_reads": {
+            "type": "long"
+          },
+          "total_bases": {
+            "type": "long"
+          },
+          "total_reads": {
+            "type": "long"
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
Adds `metrics` object to the mapping for the file-centric index. From: https://github.com/icgc-argo/files-service/pull/104